### PR TITLE
Adição da Regra 91: Anomalia no espaçotempo

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -83,3 +83,4 @@
 81. Caso seu X-bacon caia durante a batalha, o akernaak esta proibido de gritar birrrl.
 82. Se Sauron aparecer, destrua seu anel.
 83. Caso você encontre o chamado do ronaldo pelo rádio intergalático, chame-o para o seu lado pois a frota dele será de grande ajuda.
+84. Caso o Senhor Madruga seja visto, toda a frota estelar estará devendo 1000 Dracmas ao Senhor Barriga.


### PR DESCRIPTION
# Adição da Regra 91: Anomalia no espaçotempo.


    Regra 91: Viajar em velocidades que excedem 2x a velocidade de dobra causa 50% de chance de criação de anomalias no espaçotempo. 
